### PR TITLE
Refactor and update API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,12 @@ jobs:
       - run: goreleaser
   test:
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run: |
-              go get -u golang.org/x/lint/golint
-              go get honnef.co/go/tools/cmd/staticcheck
+              go install golang.org/x/lint/golint@latest
+              go install honnef.co/go/tools/cmd/staticcheck@latest
               go list ./pkg/... | grep -v vendor | xargs golint -set_exit_status
               go list ./pkg/... | grep -v vendor | xargs go vet
               staticcheck ./pkg/...

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/stretchr/testify v1.7.2
+	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fairwindsops/controller-utils
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -59,6 +59,7 @@ type Workload struct {
 	RunningPodCount int
 }
 
+// Client is used to interact with the Kubernetes API
 type Client struct {
 	Context    context.Context
 	Dynamic    dynamic.Interface
@@ -160,9 +161,9 @@ func (client Client) getAllTopControllers(namespace string, includePods bool) ([
 			}
 			existingWorkload.PodSpec = podSpec
 		}
-		existingWorkload.PodCount += 1
+		existingWorkload.PodCount++
 		if getPodStatus(pod) == podStatusRunning {
-			existingWorkload.RunningPodCount += 1
+			existingWorkload.RunningPodCount++
 		}
 		if includePods {
 			existingWorkload.Pods = append(existingWorkload.Pods, pod)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -182,23 +182,6 @@ func getControllerKey(controller unstructured.Unstructured) string {
 	return fmt.Sprintf("%s/%s/%s", controller.GetKind(), controller.GetNamespace(), controller.GetName())
 }
 
-func dedupePods(pods []unstructured.Unstructured) []unstructured.Unstructured {
-	var dedupedPods []unstructured.Unstructured
-	dedupeMap := map[string]unstructured.Unstructured{}
-	for _, pod := range pods {
-		owners := pod.GetOwnerReferences()
-		if len(owners) == 0 {
-			dedupedPods = append(dedupedPods, pod)
-			continue
-		}
-		dedupeMap[fmt.Sprintf("%s/%s/%s", pod.GetNamespace(), owners[0].Kind, owners[0].Name)] = pod
-	}
-	for _, pod := range dedupeMap {
-		dedupedPods = append(dedupedPods, pod)
-	}
-	return dedupedPods
-}
-
 // GetTopController finds the highest level owner of whatever object is passed in.
 func (client Client) GetTopController(unstructuredObject unstructured.Unstructured, objectCache map[string]unstructured.Unstructured) (unstructured.Unstructured, error) {
 	owners := unstructuredObject.GetOwnerReferences()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -158,9 +158,7 @@ func (client Client) getAllTopControllers(namespace string, includePods bool) ([
 					return nil, err
 				}
 			}
-			if err != nil {
-				existingWorkload.PodSpec = podSpec
-			}
+			existingWorkload.PodSpec = podSpec
 		}
 		existingWorkload.PodCount += 1
 		if getPodStatus(pod) == podStatusRunning {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,7 +32,7 @@ import (
 const podStatusRunning = "Running"
 
 type knownKind struct {
-	kind string
+	kind       string
 	apiVersion string
 }
 
@@ -52,16 +52,16 @@ var knownKinds = []knownKind{{
 
 // Workload represents a workload in the cluster. It contains the top level object and all of the pods.
 type Workload struct {
-	TopController unstructured.Unstructured
-	Pods          []unstructured.Unstructured
-	PodSpec *corev1.PodSpec
-	PodCount int
+	TopController   unstructured.Unstructured
+	Pods            []unstructured.Unstructured
+	PodSpec         *corev1.PodSpec
+	PodCount        int
 	RunningPodCount int
 }
 
 type Client struct {
-	Context context.Context
-	Dynamic dynamic.Interface
+	Context    context.Context
+	Dynamic    dynamic.Interface
 	RESTMapper meta.RESTMapper
 }
 
@@ -130,7 +130,7 @@ func (client Client) getAllTopControllers(namespace string, includePods bool) ([
 		}
 		workloadMap[key] = Workload{
 			TopController: controller,
-			PodSpec: podSpec,
+			PodSpec:       podSpec,
 		}
 	}
 	pods, err := client.getAllPods(namespace)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -60,19 +60,19 @@ type Workload struct {
 }
 
 type Client struct {
-	ctx context.Context
-	dynamic dynamic.Interface
-	restMapper meta.RESTMapper
+	Context context.Context
+	Dynamic dynamic.Interface
+	RESTMapper meta.RESTMapper
 }
 
 func (client Client) getAllPods(namespace string) ([]unstructured.Unstructured, error) {
 	fqKind := schema.FromAPIVersionAndKind("v1", "Pod")
-	mapping, err := client.restMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
+	mapping, err := client.RESTMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
 	if err != nil {
 		log.GetLogger().Error(err, "Error retrieving mapping", "v1", "Pod")
 		return nil, err
 	}
-	pods, err := client.dynamic.Resource(mapping.Resource).Namespace(namespace).List(client.ctx, metav1.ListOptions{})
+	pods, err := client.Dynamic.Resource(mapping.Resource).Namespace(namespace).List(client.Context, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -235,13 +235,13 @@ func (client Client) GetTopController(unstructuredObject unstructured.Unstructur
 func (client Client) cacheAllObjectsOfKind(apiVersion, kind, namespace string, objectCache map[string]unstructured.Unstructured, mustNotHaveOwner bool) error {
 	log.GetLogger().V(9).Info("cache all", apiVersion, kind)
 	fqKind := schema.FromAPIVersionAndKind(apiVersion, kind)
-	mapping, err := client.restMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
+	mapping, err := client.RESTMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
 	if err != nil {
 		log.GetLogger().Error(err, "Error retrieving mapping", apiVersion, kind)
 		return err
 	}
 
-	objects, err := client.dynamic.Resource(mapping.Resource).Namespace(namespace).List(client.ctx, metav1.ListOptions{})
+	objects, err := client.Dynamic.Resource(mapping.Resource).Namespace(namespace).List(client.Context, metav1.ListOptions{})
 	if err != nil {
 		log.GetLogger().Error(err, "Error retrieving parent object", mapping.Resource.Version, mapping.Resource.Resource)
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -104,14 +104,15 @@ func (client Client) prepCacheWithKnownControllers(namespace string, objectCache
 	return nil
 }
 
-// GetAllTopControllersSummary returns the highest level owning object of all pods, as well as all pods.
+// GetAllTopControllersSummary returns the highest level owning object of all pods
 // If a namespace is provided than this is limited to that namespace.
 // This can be more memory-efficient than GetAllTopControllersWithPods, since it does not include individual pods.
 func (client Client) GetAllTopControllersSummary(namespace string) ([]Workload, error) {
 	return client.getAllTopControllers(namespace, false)
 }
 
-// GetAllTopControllersWithPods returns the highest level owning object of all pods. If a namespace is provided than this is limited to that namespace.
+// GetAllTopControllersWithPods returns the highest level owning object of all pods, as well as all pods.
+// If a namespace is provided than this is limited to that namespace.
 func (client Client) GetAllTopControllersWithPods(namespace string) ([]Workload, error) {
 	return client.getAllTopControllers(namespace, true)
 }
@@ -231,7 +232,7 @@ func (client Client) GetTopController(unstructuredObject unstructured.Unstructur
 	return unstructuredObject, nil
 }
 
-func (client Client) cacheAllObjectsOfKind(apiVersion, kind, namespace string, objectCache map[string]unstructured.Unstructured, mustNotHaveOwner bool) error {
+func (client Client) cacheAllObjectsOfKind(apiVersion, kind, namespace string, objectCache map[string]unstructured.Unstructured, mustBeTopLevel bool) error {
 	log.GetLogger().V(9).Info("cache all", apiVersion, kind)
 	fqKind := schema.FromAPIVersionAndKind(apiVersion, kind)
 	mapping, err := client.RESTMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
@@ -246,7 +247,7 @@ func (client Client) cacheAllObjectsOfKind(apiVersion, kind, namespace string, o
 		return err
 	}
 	for idx, object := range objects.Items {
-		if mustNotHaveOwner && len(object.GetOwnerReferences()) > 0 {
+		if mustBeTopLevel && len(object.GetOwnerReferences()) > 0 {
 			continue
 		}
 		key := getControllerKey(object)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -141,9 +141,9 @@ func setupFakeData(t *testing.T) (Client, unstructured.Unstructured, unstructure
 	_, err = dynamic.Resource(mapping.Resource).Namespace("test").Create(context.TODO(), &depNoPods, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	client := Client{
-		dynamic: dynamic,
-		restMapper: restMapper,
-		ctx: context.TODO(),
+		Dynamic: dynamic,
+		RESTMapper: restMapper,
+		Context: context.TODO(),
 	}
 	return client, pod, rs, dep, pod2
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -141,9 +141,9 @@ func setupFakeData(t *testing.T) (Client, unstructured.Unstructured, unstructure
 	_, err = dynamic.Resource(mapping.Resource).Namespace("test").Create(context.TODO(), &depNoPods, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	client := Client{
-		Dynamic: dynamic,
+		Dynamic:    dynamic,
 		RESTMapper: restMapper,
-		Context: context.TODO(),
+		Context:    context.TODO(),
 	}
 	return client, pod, rs, dep, pod2
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -165,10 +165,10 @@ func TestGetTopController(t *testing.T) {
 
 func TestGetAllTopControllers(t *testing.T) {
 	client, _, _, _, _ := setupFakeData(t)
-	controllers, err := client.GetAllTopControllers("")
+	controllers, err := client.GetAllTopControllersSummary("")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(controllers))
-	controllers, err = client.GetAllTopControllers("test")
+	controllers, err = client.GetAllTopControllersSummary("test")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(controllers))
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -15,7 +15,6 @@
 package controller
 
 import (
-	"errors"
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +31,7 @@ func GetPodSpec(obj map[string]interface{}) (*corev1.PodSpec, error) {
 		}
 	}
 	if _, ok := obj["containers"]; !ok {
-		return nil, errors.New("No podSpec found")
+		return nil, nil
 	}
 	b, err := json.Marshal(obj)
 	if err != nil {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -19,23 +19,28 @@ import (
 	"io/ioutil"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPodSpec(t *testing.T) {
-	podSpec := readPodSpecFile(t, "./tests/deployment.json")
+	podSpec, err := readPodSpecFile(t, "./tests/deployment.json")
+	assert.NoError(t, err)
 	assert.NotNil(t, podSpec)
-	assert.Equal(t, 1, len(podSpec.(map[string]interface{})["containers"].([]interface{})))
-	podSpec = readPodSpecFile(t, "./tests/secret.json")
+	assert.Equal(t, 1, len(podSpec.Containers))
+
+	podSpec, err = readPodSpecFile(t, "./tests/secret.json")
+	assert.Error(t, err)
 	assert.Nil(t, podSpec)
 }
 
-func readPodSpecFile(t *testing.T, file string) interface{} {
+func readPodSpecFile(t *testing.T, file string) (*corev1.PodSpec, error) {
 	contents, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 	var object map[string]interface{}
 	err = json.Unmarshal(contents, &object)
 	assert.NoError(t, err)
 	return GetPodSpec(object)
-
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -16,7 +16,7 @@ package controller
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +36,7 @@ func TestGetPodSpec(t *testing.T) {
 }
 
 func readPodSpecFile(t *testing.T, file string) (*corev1.PodSpec, error) {
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	assert.NoError(t, err)
 	var object map[string]interface{}
 	err = json.Unmarshal(contents, &object)

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -21,7 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -32,7 +32,7 @@ func TestGetPodSpec(t *testing.T) {
 	assert.Equal(t, 1, len(podSpec.Containers))
 
 	podSpec, err = readPodSpecFile(t, "./tests/secret.json")
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, podSpec)
 }
 


### PR DESCRIPTION
This PR adds some new functionality and refactors old code

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
* Some issues w/ memory when returning all pods in the cluster
* Helps distinguish running pods from completed pods
* Easier function footprints

### What changes did you make?
* GetPodSpec now returns a pod spec instead of a `map[string]interface{}`
* Everything uses a `client` object now, instead of passing around dynamicInterface and RESTMapper
* `GetAllTopControllers` has been split in two:
  * `GetAllTopControllersSummary`, which does not return individual pods
  * `GetAllTopControllersWithPods`, which does return pods

### What alternative solution should we consider, if any?