### PR TITLE
Add `GetAllPersistentVolumeClaims` to return all PVCs as unstructured objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.2
+* Add `GetAllPersistentVolumeClaims()` which returns all PVCs as unstructured objects.`
+
 ## 0.1.1
 * Bumped Go to 1.17
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -117,6 +117,21 @@ func (client Client) GetAllTopControllersWithPods(namespace string) ([]Workload,
 	return client.getAllTopControllers(namespace, true)
 }
 
+// GetAllPersistentVolumeClaims returns all PVCs as unstructured objects.
+func (client Client) GetAllPersistentVolumeClaims(namespace string) ([]unstructured.Unstructured, error) {
+	fqKind := schema.FromAPIVersionAndKind("v1", "PersistentVolumeClaim")
+	mapping, err := client.RESTMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
+	if err != nil {
+		log.GetLogger().Error(err, "Error retrieving mapping", "v1", "PersistentVolumeClaim")
+		return nil, err
+	}
+	PVCs, err := client.Dynamic.Resource(mapping.Resource).Namespace(namespace).List(client.Context, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return PVCs.Items, nil
+}
+
 func (client Client) getAllTopControllers(namespace string, includePods bool) ([]Workload, error) {
 	workloadMap := map[string]Workload{}
 	objectCache := map[string]unstructured.Unstructured{}


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add a function to fetch PVCs from in-cluster and return them as `unstructured.Unstructured` types.

Ticket: https://fairwinds.myjetbrains.com/youtrack/issue/FWI-3766/Update-controller-utils-to-fetch-PersistentVolumeClaims